### PR TITLE
Exclude Krita manual preview from search indexer

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /docs-krita-org_zh-tw/


### PR DESCRIPTION
官方說明文件會發佈到 docs.krita.org，而 https://github.com/l10n-tw/docs-krita-org_zh-tw 的 GitHub Pages 只是用來給翻譯者預覧，因此應防止搜尋器檢索這個 GitHub Pages 避免混淆。